### PR TITLE
o20c9dkG [test-3c] CompatHelper: bump compat for "PGFPlotsX" to "1.2" (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 IterableTables = "1"
-PGFPlotsX = "~1.0.0"
+PGFPlotsX = "~1.0.0, 1.2"
 julia = "1.2"
 
 [extras]


### PR DESCRIPTION
This pull request changes the compat entry for the `PGFPlotsX` package from `~1.0.0` to `~1.0.0, 1.2`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.