### PR TITLE
TbycCtgn [test-3c] CompatHelper: add new compat entry for "DataFrames" at version "1.1"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ PGFPlotsX = "8314cec4-20b6-5062-9cdb-752b83310925"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+DataFrames = "1.1"
 IterableTables = "1"
 PGFPlotsX = "~1.0.0"
 julia = "1.2"


### PR DESCRIPTION
This pull request sets the compat entry for the `DataFrames` package to `1.1`.

This is a brand new compat entry. Previously, you did not have a compat entry for the `DataFrames` package.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.

Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.