### PR TITLE
U6y9Oyzb [test-2c] CompatHelper: add new compat entry for "Flux" at version "0.12"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 
 [compat]
 DataFrames = "0.19"
+Flux = "0.12"
 julia = "1.2"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `Flux` package to `0.12`.

This is a brand new compat entry. Previously, you did not have a compat entry for the `Flux` package.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.

Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.