### PR TITLE
Sz0mZSq9 [test-6c] CompatHelper: bump compat for PGFPlotsX to
    1  for package subdir_2,  (keep existing compat)

### DIFF
--- a/subdir_2/Project.toml
+++ b/subdir_2/Project.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 PGFPlotsX = "8314cec4-20b6-5062-9cdb-752b83310925"
 
 [compat]
-PGFPlotsX = "~1.0.0"
+PGFPlotsX = "~1.0.0, 1"
 julia = "1.2"
 
 [extras]


### PR DESCRIPTION
This pull request changes the compat entry for the `PGFPlotsX` package from `~1.0.0` to `~1.0.0, 1`  for package subdir_2. This keeps the compat entries for earlier versions.


    Note: I have not tested your package with this new compat entry.
    It is your responsibility to make sure that your package tests pass before you merge this pull request.