### PR TITLE
n52pwDhw [test-2c] CompatHelper: bump compat for DataFrames to
    1 ,  (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 
 [compat]
-DataFrames = "0.19"
+DataFrames = "0.19, 1"
 julia = "1.2"
 
 [extras]


### PR DESCRIPTION
This pull request changes the compat entry for the `DataFrames` package from `0.19` to `0.19, 1` . This keeps the compat entries for earlier versions.


    Note: I have not tested your package with this new compat entry.
    It is your responsibility to make sure that your package tests pass before you merge this pull request.