### PR TITLE
zJmgi1nJ [test-7b] CompatHelper: add new compat entry for BioSequences at version
    2 ,  (drop existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 
 [compat]
+BioSequences = "2"
 DataFrames = "=0.19.0"
 julia = "1.2"
 


### PR DESCRIPTION
This pull request sets the compat entry for the `BioSequences` package to `2` . This drops the compat entries for earlier versions.


    Note: I have not tested your package with this new compat entry.
    It is your responsibility to make sure that your package tests pass before you merge this pull request.
    Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.