### PR TITLE
RQ8LD087 [test-3c] CompatHelper: add new compat entry for BioSequences at version 3, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ PGFPlotsX = "8314cec4-20b6-5062-9cdb-752b83310925"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+BioSequences = "3"
 IterableTables = "1"
 PGFPlotsX = "~1.0.0"
 julia = "1.2"


### PR DESCRIPTION
This pull request sets the compat entry for the `BioSequences` package to `3`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.