### PR TITLE
PehmRSa8 [test-10a] CompatHelper: bump compat for PGFPlotsX in [weakdeps] to 1, (drop existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Ext = ["BioSequences", "DataFrames", "Flux", "IterableTables", "Nettle_jll", "PG
 
 [compat]
 IterableTables = "1"
-PGFPlotsX = "~1.0.0"
+PGFPlotsX = "1"
 julia = "1.2"
 
 [extras]


### PR DESCRIPTION
This pull request changes the compat entry for the `PGFPlotsX` package from `~1.0.0` to `1`.
This drops the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.