### PR TITLE
PehmRSa8 [test-10b] CompatHelper: add new compat entry for Flux in [weakdeps] at version 0.14, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Ext = ["BioSequences", "DataFrames", "Flux", "IterableTables", "Nettle_jll", "PGFPlotsX"]
 
 [compat]
+Flux = "0.14"
 IterableTables = "1"
 PGFPlotsX = "~1.0.0"
 julia = "1.2"


### PR DESCRIPTION
This pull request sets the compat entry for the `Flux` package to `0.14`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.